### PR TITLE
Add article links

### DIFF
--- a/client/components/use-case-wrapper.js
+++ b/client/components/use-case-wrapper.js
@@ -6,6 +6,7 @@ import Link from 'next/link';
 export function UseCaseWrapper({
   title,
   description,
+  articleURL,
   listItems,
   children,
   variant,
@@ -25,22 +26,33 @@ export function UseCaseWrapper({
               {listItems?.map((item, index) => (
                 <li key={index}>{item}</li>
               ))}
+              <li>
+                You can reset this scenario on the <Link href="/admin">admin page</Link>.
+              </li>
+              {articleURL && (
+                <li>
+                  Learn more about this scenario in the{' '}
+                  <a
+                  href={articleURL}
+                  target="_blank"
+                  rel="noreferrer"
+                  >
+                    {title}
+                  </a>
+                  {' '}article.
+                </li>
+              )}
               {!hideSrcListItem && (
-                <>
-                  <li>
-                  You can reset this scenario on the <Link href="/admin">admin page</Link>.
-                  </li>
-                  <li>
-                    Need src?{' '}
-                    <a
-                      href="https://github.com/fingerprintjs/fingerprintjs-pro-use-cases"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      Sure!
-                    </a>
-                  </li>
-                </>
+                <li>
+                  Need src?{' '}
+                  <a
+                    href="https://github.com/fingerprintjs/fingerprintjs-pro-use-cases"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Sure!
+                  </a>
+                </li>
               )}
             </ul>
           </div>

--- a/pages/api/admin/reset.js
+++ b/pages/api/admin/reset.js
@@ -17,7 +17,6 @@ import { UserCartItem, UserPreferences, UserSearchHistory } from '../../../serve
 import { LoanRequest } from '../../../server/loan-risk/database';
 import { ArticleView } from '../../../server/paywall/database';
 
-
 export default async function handler(req, res) {
   // This API route accepts only POST requests.
   if (req.method !== 'POST') {

--- a/pages/credential-stuffing/index.js
+++ b/pages/credential-stuffing/index.js
@@ -108,7 +108,7 @@ export default function Index() {
         <>If you provide the wrong credentials 5 times, you&apos;d be locked out!</>,
         <>
           {' '}
-          U h4ck3r? You can try to generate new <code>visitorId</code> and <code>reqeustId</code> and try to log in.
+          U h4ck3r? You can try to generate new <code>visitorId</code> and <code>requestId</code> and try to log in.
           Good luck :)
         </>,
       ]}

--- a/pages/credential-stuffing/index.js
+++ b/pages/credential-stuffing/index.js
@@ -99,6 +99,7 @@ export default function Index() {
           <code>password</code>. It will be very hard...
         </>
       }
+      articleURL="https://fingerprint.com/use-cases/credential-stuffing/"
       listItems={[
         <>
           Even with correct credentials, you cannot log in if the system does not recognize your <code>visitorId</code>.

--- a/pages/payment-fraud/index.js
+++ b/pages/payment-fraud/index.js
@@ -86,6 +86,7 @@ export default function Index() {
     <UseCaseWrapper
       title="Payment Fraud problem"
       description=" This page demonstrates protected credit card form protected against different fraud."
+      articleURL="https://fingerprint.com/use-cases/payment-fraud/"
       listItems={[
         <>
           Only prefilled card details are correct. When you change them, the system will check if you tried to perform

--- a/pages/personalization/index.js
+++ b/pages/personalization/index.js
@@ -106,6 +106,7 @@ export default function Index() {
           </>,
         ]}
         description="This page demonstrates user personalization that is achieved by Fingerprint Pro. Users don't need to login in to get a tailored experience."
+        articleURL="https://fingerprint.com/use-cases/personalization/"
       >
         <PersonalizationTopSection
           search={search}


### PR DESCRIPTION
Closes #28 by linking the articles on the corresponding page. There currently isn't a use case example for account sharing prevention, so this has been excluded. A typo was corrected on the credential stuffing page, and prettier was ran which removed an empty line in an api route.

![image](https://user-images.githubusercontent.com/11049493/195187754-4ec5b75b-ebda-4846-bb28-c95bc1cdecc9.png)
![image](https://user-images.githubusercontent.com/11049493/195187801-e515d929-e2ce-46a8-bf53-c44a141b611a.png)
The hyperlink uses the title parameter passed to UseCaseWrapper component and so there is "problem" added to the end of some pages which is redundant and could possibly be removed from the title (see above image). 
Reset Scenario has been moved out of the  hideSrcListItem condition as to allow the article to be above the src line, so reset scenario will show up on all usecase pages. 