### PR TITLE
fix: Web scraping - Make checks order more secure?

### DIFF
--- a/pages/api/web-scraping/flights.ts
+++ b/pages/api/web-scraping/flights.ts
@@ -69,20 +69,6 @@ export default async function getFlights(req: NextApiRequest, res: NextApiRespon
     return;
   }
 
-  // Check for bot presence and type
-  if (botData.bot?.result === 'good') {
-    sendOkResponse(
-      res,
-      new CheckResult(
-        'Access allowed, good bot detected.',
-        messageSeverity.Success,
-        checkResultType.GoodBotDetected,
-        getFlightResults(from, to)
-      )
-    );
-    return;
-  }
-
   if (botData.bot?.result === 'bad') {
     sendForbiddenResponse(
       res,
@@ -97,7 +83,7 @@ export default async function getFlights(req: NextApiRequest, res: NextApiRespon
     return;
   }
 
-  if (botData.bot?.result !== 'notDetected') {
+  if (botData.bot?.result !== 'notDetected' && botData.bot.result !== 'good') {
     sendErrorResponse(
       res,
       new CheckResult(
@@ -109,7 +95,8 @@ export default async function getFlights(req: NextApiRequest, res: NextApiRespon
     return;
   }
 
-  // We know bot is 'notDetected', verify the visit data
+  // We know bot is 'notDetected' or 'good', but
+  // we must verify the authenticity of the botDetection result
   // Check if the visit IP matches the request IP
   if (!visitIpMatchesRequestIp(botData.ip, req)) {
     sendForbiddenResponse(
@@ -145,7 +132,7 @@ export default async function getFlights(req: NextApiRequest, res: NextApiRespon
   sendOkResponse(
     res,
     new CheckResult(
-      'No bot nor spoofing detected, access allowed.',
+      'No malicious bot nor spoofing detected, access allowed.',
       messageSeverity.Success,
       checkResultType.Passed,
       getFlightResults(from, to)

--- a/pages/api/web-scraping/flights.ts
+++ b/pages/api/web-scraping/flights.ts
@@ -83,7 +83,7 @@ export default async function getFlights(req: NextApiRequest, res: NextApiRespon
     return;
   }
 
-  if (botData.bot?.result !== 'notDetected' && botData.bot.result !== 'good') {
+  if (!['notDetected', 'good'].includes(botData.bot?.result)) {
     sendErrorResponse(
       res,
       new CheckResult(


### PR DESCRIPTION
I realized that maybe the current order of checks has a small vulnerability? 

* Right now, if we detect a good bot, we send the results without checking the authenticity of the bot detection result. 
* If the attacker managed to pass as a good bot *just once* for the given subscription, they could reuse that `requestId` infinitely to scrape data. 
* With this change, they would need to be able to pass as a good bot every time. 
* Sure, if you can do it once, you can probably do it repeatedly, but it still seems better to check the authenticity of the requestId for good bots, not just undetected bots. Coincidentally, it shortens and simplifies the endpoint function.

What do you think? @makma @TheUnderScorer @ilfa 

