### PR TITLE
Feat/new smart signals2 on playground INTER-45

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+PRIVATE_API_KEY=<SECRET_API_KEY>
+NEXT_PUBLIC_API_KEY=<PUBLIC_API_KEY>
+# "eu" or "ap", "us" is default
+BACKEND_REGION=<REGION>
+# "eu" or "ap", "us" is default
+NEXT_PUBLIC_FRONTEND_REGION=<REGION>

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+env:
+  # Playwright headless browsers running in CI get low confidence scores, causing flaky tests. Lower the confidence score threshold for CI testing.
+  MIN_CONFIDENCE_SCORE: 0
 jobs:
   test:
     timeout-minutes: 60

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ tsconfig.tsbuildinfo
 /playwright-report/
 /playwright/.cache/
 
+# environment variables
+.env
+

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ tsconfig.tsbuildinfo
 # environment variables
 .env
 
+.vscode

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@emotion/styled": "^11.9.3",
     "@fingerprintjs/fingerprintjs-pro": "^3.6.2",
     "@fingerprintjs/fingerprintjs-pro-react": "^2.3.0",
-    "@fingerprintjs/fingerprintjs-pro-server-api": "^2.1.0",
+    "@fingerprintjs/fingerprintjs-pro-server-api": "^2.3.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/lab": "^5.0.0-alpha.134",
     "@mui/material": "^5.13.5",

--- a/pages/api/event/[requestId].ts
+++ b/pages/api/event/[requestId].ts
@@ -1,11 +1,11 @@
-import { FingerprintJsServerApiClient, Region, isEventError } from '@fingerprintjs/fingerprintjs-pro-server-api';
+import { FingerprintJsServerApiClient, isEventError } from '@fingerprintjs/fingerprintjs-pro-server-api';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { SERVER_API_KEY } from '../../../server/const';
+import { BACKEND_REGION, SERVER_API_KEY } from '../../../server/const';
 
 export default async function getFingerprintEvent(req: NextApiRequest, res: NextApiResponse) {
   const { requestId } = req.query as { requestId: string };
   const client = new FingerprintJsServerApiClient({
-    region: Region.Global,
+    region: BACKEND_REGION,
     apiKey: SERVER_API_KEY,
   });
   try {

--- a/pages/api/web-scraping/flights.ts
+++ b/pages/api/web-scraping/flights.ts
@@ -1,9 +1,9 @@
-import { EventResponse, FingerprintJsServerApiClient, Region } from '@fingerprintjs/fingerprintjs-pro-server-api';
+import { EventResponse, FingerprintJsServerApiClient } from '@fingerprintjs/fingerprintjs-pro-server-api';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { Flight } from '../../../client/components/web-scraping/FlightCard';
 import { CheckResult, CheckResultObject, checkResultType } from '../../../server/checkResult';
 import { isRequestIdFormatValid, originIsAllowed, visitIpMatchesRequestIp } from '../../../server/checks';
-import { ALLOWED_REQUEST_TIMESTAMP_DIFF_MS, SERVER_API_KEY } from '../../../server/const';
+import { ALLOWED_REQUEST_TIMESTAMP_DIFF_MS, BACKEND_REGION, SERVER_API_KEY } from '../../../server/const';
 import { sendErrorResponse, sendForbiddenResponse, sendOkResponse } from '../../../server/response';
 import { ensurePostRequest, messageSeverity } from '../../../server/server';
 import { DAY_MS, FIVE_MINUTES_MS, HOUR_MS } from '../../../shared/const';
@@ -36,7 +36,7 @@ export default async function getFlights(req: NextApiRequest, res: NextApiRespon
   // Retrieve analysis event from the Server API using the request ID
   let botData: EventResponse['products']['botd']['data'] | undefined;
   try {
-    const client = new FingerprintJsServerApiClient({ region: Region.Global, apiKey: SERVER_API_KEY });
+    const client = new FingerprintJsServerApiClient({ region: BACKEND_REGION, apiKey: SERVER_API_KEY });
     const eventResponse = await client.getEvent(requestId);
     botData = eventResponse.products?.botd?.data;
   } catch (error) {

--- a/pages/playground/index.tsx
+++ b/pages/playground/index.tsx
@@ -196,7 +196,7 @@ function Playground() {
       {
         content: [
           'Virtual machine',
-          <Info key="info">The browser is running inside a virtual machine (e.g. VMWare).</Info>,
+          <Info key="info">The browser is running inside a virtual machine (e.g., VMWare).</Info>,
         ],
       },
       {
@@ -277,6 +277,42 @@ function Playground() {
         content: [
           'Android Tampering',
           <Info key="info">Android specific root management apps detection, for example, Magisk.</Info>,
+        ],
+      },
+      { content: 'Not applicable to browsers', cellStyle: { backgroundColor: GRAY } },
+    ],
+    [
+      {
+        content: [
+          'Android Cloned Application',
+          <Info key="info">Android-specific detection of a fully cloned application present on the device.</Info>,
+        ],
+      },
+      { content: 'Not applicable to browsers', cellStyle: { backgroundColor: GRAY } },
+    ],
+    [
+      {
+        content: [
+          'Android Factory Reset',
+          <Info key="info">Timestamp of a recent factory reset on an Android device.</Info>,
+        ],
+      },
+      { content: 'Not applicable to browsers', cellStyle: { backgroundColor: GRAY } },
+    ],
+    [
+      {
+        content: ['iOS Jailbreak', <Info key="info">Jailbreak detected on an iOS device.</Info>],
+      },
+      { content: 'Not applicable to browsers', cellStyle: { backgroundColor: GRAY } },
+    ],
+    [
+      {
+        content: [
+          'iOS Frida installation',
+          <Info key="info">
+            Frida installation detected on an iOS device. Frida is a code-orchestration tool allowing to inject
+            arbitrary code into the operating system.
+          </Info>,
         ],
       },
       { content: 'Not applicable to browsers', cellStyle: { backgroundColor: GRAY } },

--- a/pages/playground/index.tsx
+++ b/pages/playground/index.tsx
@@ -200,10 +200,8 @@ function Playground() {
         ],
       },
       {
-        // @ts-expect-error
         content: usedIdentificationEvent?.products?.virtualMachine?.data?.result === true ? 'Yes ☁️💻' : 'Not detected',
         cellStyle: {
-          // @ts-expect-error
           backgroundColor: usedIdentificationEvent?.products?.virtualMachine?.data?.result === true ? RED : GREEN,
         },
       },
@@ -219,10 +217,8 @@ function Playground() {
       },
       {
         content:
-          // @ts-expect-error
           usedIdentificationEvent?.products?.privacySettings?.data?.result === true ? 'Yes 🙈💻' : 'Not detected',
         cellStyle: {
-          // @ts-expect-error
           backgroundColor: usedIdentificationEvent?.products?.privacySettings?.data?.result === true ? RED : GREEN,
         },
       },

--- a/pages/playground/index.tsx
+++ b/pages/playground/index.tsx
@@ -180,8 +180,8 @@ function Playground() {
         content: [
           'Browser Tampering',
           <Info key="info">
-            Flag indicating whether browser tampering was detected according to our internal thresholds. For example, if
-            the reported user agent is not consistent with other browser attributes.
+            Browser tampering was detected according to our internal thresholds. For example, if the reported user agent
+            is not consistent with other browser attributes.
           </Info>,
         ],
       },
@@ -189,6 +189,41 @@ function Playground() {
         content: usedIdentificationEvent?.products?.tampering?.data?.result === true ? 'Yes 🖥️🔧' : 'Not detected',
         cellStyle: {
           backgroundColor: usedIdentificationEvent?.products?.tampering?.data?.result === true ? RED : GREEN,
+        },
+      },
+    ],
+    [
+      {
+        content: [
+          'Virtual machine',
+          <Info key="info">The browser is running inside a virtual machine (e.g. VMWare).</Info>,
+        ],
+      },
+      {
+        // @ts-expect-error
+        content: usedIdentificationEvent?.products?.virtualMachine?.data?.result === true ? 'Yes ☁️💻' : 'Not detected',
+        cellStyle: {
+          // @ts-expect-error
+          backgroundColor: usedIdentificationEvent?.products?.virtualMachine?.data?.result === true ? RED : GREEN,
+        },
+      },
+    ],
+    [
+      {
+        content: [
+          'Privacy settings',
+          <Info key="info">
+            The visitor is using a privacy aware browser (e.g., Tor) or a browser in which fingerprinting is blocked.
+          </Info>,
+        ],
+      },
+      {
+        content:
+          // @ts-expect-error
+          usedIdentificationEvent?.products?.privacySettings?.data?.result === true ? 'Yes 🙈💻' : 'Not detected',
+        cellStyle: {
+          // @ts-expect-error
+          backgroundColor: usedIdentificationEvent?.products?.privacySettings?.data?.result === true ? RED : GREEN,
         },
       },
     ],

--- a/server/const.ts
+++ b/server/const.ts
@@ -5,8 +5,6 @@ export const ALLOWED_REQUEST_TIMESTAMP_DIFF_MS = 3000;
 // Confidence score thresholds might be different for different scenarios
 export const MIN_CONFIDENCE_SCORE = process.env.MIN_CONFIDENCE_SCORE ? Number(process.env.MIN_CONFIDENCE_SCORE) : 0.85;
 
-console.log('MIN_CONFIDENCE_SCORE', MIN_CONFIDENCE_SCORE);
-
 const BackendRegionMap = {
   eu: Region.EU,
   ap: Region.AP,

--- a/server/const.ts
+++ b/server/const.ts
@@ -1,15 +1,22 @@
-// @ts-check
+import { Region } from '@fingerprintjs/fingerprintjs-pro-server-api';
+
 export const IPv4_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.){3}(25[0-5]|(2[0-4]|1\d|[1-9]|)\d)$/;
 export const ALLOWED_REQUEST_TIMESTAMP_DIFF_MS = 3000;
 // Confidence score thresholds might be different for different scenarios
 export const MIN_CONFIDENCE_SCORE = 0.85;
 
+const BackendRegionMap = {
+  eu: Region.EU,
+  ap: Region.AP,
+  us: Region.Global,
+};
+
 // Warning: In the real world The Server API key should be secretly stored in the environment variables/secrets.
 // We are keeping it here just to make it easy to run the demo.
 export const SERVER_API_KEY = process.env.PRIVATE_API_KEY ?? 'F6gQ8H8vQLc7mVsVKaFx';
 export const PUBLIC_API_KEY = process.env.NEXT_PUBLIC_API_KEY ?? 'rzpSduhT63F6jaS35HFo';
-export const BACKEND_REGION = process.env.BACKEND_REGION ?? 'Global';
 export const FRONTEND_REGION = process.env.NEXT_PUBLIC_FRONTEND_REGION ?? 'us';
+export const BACKEND_REGION: Region = BackendRegionMap[process.env.BACKEND_REGION] ?? Region.Global;
 export const SCRIPT_URL_PATTERN =
   process.env.NEXT_PUBLIC_SCRIPT_URL_PATTERN ??
   'https://fpcf.fingerprinthub.com/DBqbMN7zXxwl4Ei8/J5XlHIBN67YHskdR?apiKey=<apiKey>&version=<version>&loaderVersion=<loaderVersion>';

--- a/server/const.ts
+++ b/server/const.ts
@@ -3,7 +3,7 @@ import { Region } from '@fingerprintjs/fingerprintjs-pro-server-api';
 export const IPv4_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.){3}(25[0-5]|(2[0-4]|1\d|[1-9]|)\d)$/;
 export const ALLOWED_REQUEST_TIMESTAMP_DIFF_MS = 3000;
 // Confidence score thresholds might be different for different scenarios
-export const MIN_CONFIDENCE_SCORE = 0.85;
+export const MIN_CONFIDENCE_SCORE = 0.7;
 
 const BackendRegionMap = {
   eu: Region.EU,

--- a/server/const.ts
+++ b/server/const.ts
@@ -3,7 +3,7 @@ import { Region } from '@fingerprintjs/fingerprintjs-pro-server-api';
 export const IPv4_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.){3}(25[0-5]|(2[0-4]|1\d|[1-9]|)\d)$/;
 export const ALLOWED_REQUEST_TIMESTAMP_DIFF_MS = 3000;
 // Confidence score thresholds might be different for different scenarios
-export const MIN_CONFIDENCE_SCORE = 0.7;
+export const MIN_CONFIDENCE_SCORE = 0;
 
 const BackendRegionMap = {
   eu: Region.EU,

--- a/server/const.ts
+++ b/server/const.ts
@@ -3,7 +3,9 @@ import { Region } from '@fingerprintjs/fingerprintjs-pro-server-api';
 export const IPv4_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.){3}(25[0-5]|(2[0-4]|1\d|[1-9]|)\d)$/;
 export const ALLOWED_REQUEST_TIMESTAMP_DIFF_MS = 3000;
 // Confidence score thresholds might be different for different scenarios
-export const MIN_CONFIDENCE_SCORE = process.env.MIN_CONFIDENCE_SCORE ?? 0.85;
+export const MIN_CONFIDENCE_SCORE = process.env.MIN_CONFIDENCE_SCORE ? Number(process.env.MIN_CONFIDENCE_SCORE) : 0.85;
+
+console.log('MIN_CONFIDENCE_SCORE', MIN_CONFIDENCE_SCORE);
 
 const BackendRegionMap = {
   eu: Region.EU,

--- a/server/const.ts
+++ b/server/const.ts
@@ -3,7 +3,7 @@ import { Region } from '@fingerprintjs/fingerprintjs-pro-server-api';
 export const IPv4_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.){3}(25[0-5]|(2[0-4]|1\d|[1-9]|)\d)$/;
 export const ALLOWED_REQUEST_TIMESTAMP_DIFF_MS = 3000;
 // Confidence score thresholds might be different for different scenarios
-export const MIN_CONFIDENCE_SCORE = 0;
+export const MIN_CONFIDENCE_SCORE = process.env.MIN_CONFIDENCE_SCORE ?? 0.85;
 
 const BackendRegionMap = {
   eu: Region.EU,

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,10 +519,10 @@
     "@fingerprintjs/fingerprintjs-pro-spa" "^0.7.0"
     fast-deep-equal "3.1.3"
 
-"@fingerprintjs/fingerprintjs-pro-server-api@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro-server-api/-/fingerprintjs-pro-server-api-2.1.0.tgz#bb0c30cd96f6e41407a65ded15a22bc797d9f5ea"
-  integrity sha512-IYeFl1q1/f3nxwi5av7PcCChEPx2nUb+XMl7qPc2GngwH9ZeUeTS0oh3VtdMw61zJsv9U1xsdE9QyWpDBOcw9Q==
+"@fingerprintjs/fingerprintjs-pro-server-api@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@fingerprintjs/fingerprintjs-pro-server-api/-/fingerprintjs-pro-server-api-2.3.0.tgz#8cd3efba41d6b01861c69ca09d2d12f4304c7713"
+  integrity sha512-Ir10+JcHQMyANgRD+lZYz5YkqlV+QKtWmR6bP6A59mEiin7eITf2Q/JEikqpCjJagtV20G8AiesgpohGeGZj+A==
   dependencies:
     node-fetch "^2.6.1"
 


### PR DESCRIPTION
Must enable smart signals for our subscription before merging, targeting the 31st of July release day.

Demo: staging.fingerprinthub.com (I used DigitalOcean env vars to use my own subscription with all new signals enabled)