### PR TITLE
fix: add undefined checks for personalization endpoint

### DIFF
--- a/src/server/checks.js
+++ b/src/server/checks.js
@@ -38,7 +38,7 @@ export function checkFreshIdentificationRequest(visitorData) {
 // If it's lower than the certain threshold we recommend using an additional way of verification, e.g. 2FA or email.
 // More info: https://dev.fingerprint.com/docs/understanding-your-confidence-score
 export function checkConfidenceScore(visitorData) {
-  if (visitorData.visits[0].confidence.score < MIN_CONFIDENCE_SCORE) {
+  if (visitorData?.visits[0]?.confidence?.score < MIN_CONFIDENCE_SCORE) {
     return new CheckResult(
       "Low confidence score, we'd rather verify you with the second factor,",
       messageSeverity.Error,

--- a/src/server/personalization/visitor-validations.ts
+++ b/src/server/personalization/visitor-validations.ts
@@ -39,6 +39,10 @@ export async function validatePersonalizationRequest(req, res): Promise<Personal
 
   const visitorData = await getVisitorDataWithRequestId(visitorId, requestId);
 
+  if (!visitorData) {
+    return result;
+  }
+
   result.visitorId = visitorData.visitorId;
 
   for (const check of checks) {


### PR DESCRIPTION
Should mitigate this occasional runtime error: 

```
TypeError: Cannot read properties of undefined (reading 'confidence')
[fingerprintjs-pro-use-cases] [2023-09-01 00:26:39]     at checkConfidenceScore (/workspace/.next/server/chunks/3466.js:108:31)
[fingerprintjs-pro-use-cases] [2023-09-01 00:26:39]     at validatePersonalizationRequest (/workspace/.next/server/chunks/7624.js:85:35)
[fingerprintjs-pro-use-cases] [2023-09-01 00:26:39]     at runMicrotasks (<anonymous>)
[fingerprintjs-pro-use-cases] [2023-09-01 00:26:39]     at processTicksAndRejections (node:internal/process/task_queues:96:5)
[fingerprintjs-pro-use-cases] [2023-09-01 00:26:39]     at async /workspace/.next/server/chunks/7624.js:29:34
[fingerprintjs-pro-use-cases] [2023-09-01 00:26:39]     at async Object.apiResolver (/workspace/node_modules/next/dist/server/api-utils/node.js:372:9)
[fingerprintjs-pro-use-cases] [2023-09-01 00:26:39]     at async NextNodeServer.runApi (/workspace/node_modules/next/dist/server/next-server.js:513:9)
[fingerprintjs-pro-use-cases] [2023-09-01 00:26:39]     at async Object.fn (/workspace/node_modules/next/dist/server/next-server.js:815:35)
[fingerprintjs-pro-use-cases] [2023-09-01 00:26:39]     at async Router.execute (/workspace/node_modules/next/dist/server/router.js:243:32)
[fingerprintjs-pro-use-cases] [2023-09-01 00:26:39]     at async NextNodeServer.runImpl (/workspace/node_modules/next/dist/server/base-server.js:432:29)
[fingerprintjs-pro-use-cases] [2023-09-01 00:26:49] {
[fingerprintjs-pro-use-cases] [2023-09-01 00:26:49]   error: { code: 'RequestNotFound', message: 'request id not found' },
[fingerprintjs-pro-use-cases] [2023-09-01 00:26:49]   status: 404
[fingerprintjs-pro-use-cases] [2023-09-01 00:26:49] }
``` 

We will address these `undefined` situations more holistically when rewriting to TypeScript. 