### PR TITLE
chore: Make cards clickable using links and CSS INTER-263

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -7,4 +7,17 @@ test.describe('Home page', () => {
     const cards = await page.getByTestId(TEST_IDS.homepageCard.useCaseTitle);
     expect(await cards.count()).toBeGreaterThan(5);
   });
+
+  test('Entire cards should be clickable, clicking on the description or image should take you to the use case', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    await page.getByTestId(TEST_IDS.homepageCard.useCaseDescription).first().click({ force: true });
+    await expect(page).toHaveURL('/playground');
+    await page.goBack();
+
+    await page.getByTestId(TEST_IDS.homepageCard.useCaseIcon).first().click({ force: true });
+    await expect(page).toHaveURL('/playground');
+  });
 });

--- a/src/client/testIDs.ts
+++ b/src/client/testIDs.ts
@@ -18,6 +18,8 @@ export const TEST_IDS = {
   },
   homepageCard: {
     useCaseTitle: 'useCaseTitle',
+    useCaseDescription: 'useCaseDescription',
+    useCaseIcon: 'useCaseIcon',
   },
   loanRisk: {
     monthlyInstallmentValue: 'monthlyInstallmentValue',

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -67,6 +67,8 @@
   overflow: hidden;
   color: unset;
   cursor: pointer;
+  // You need this for the useCaseTitle pseudo element below
+  position: relative;
 
   @include shadowMedium();
   @include transition((box-shadow, border));
@@ -93,9 +95,25 @@
     line-height: 130%;
     margin-bottom: rem(8px);
     display: block;
+
+    /**
+     * We need to make the whole card clickable.
+     * But wrapping the whole card in a <a> element is bad for screen readers/accessibility.
+     * And using an `onClick` event on the card confuses Google Tag Manager triggers, it registers `click` instead of `linkClick`.
+     * So this is the best solution: https://kittygiraudel.com/2022/04/02/accessible-cards/
+     */
+    &::before {
+      // Use a pseudo-element to expand the hitbox of the link over the whole card.
+      content: ''; /* 1 */
+      // Expand the hitbox over the whole card.
+      position: absolute; /* 2 */
+      inset: 0; /* 2 */
+      // Place the pseudo-element on top of the whole card.
+      z-index: 1; /* 3 */
+    }
   }
 
-  .useCaseDescription {
+  .useCaseTitle .Card-Primary-Action::before .useCaseDescription {
     color: v('dark-gray');
     font-size: rem(16px);
     font-style: normal;

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -67,7 +67,7 @@
   overflow: hidden;
   color: unset;
   cursor: pointer;
-  // You need this for the useCaseTitle pseudo element below
+  // We need this for the useCaseTitle pseudo element below
   position: relative;
 
   @include shadowMedium();
@@ -113,7 +113,7 @@
     }
   }
 
-  .useCaseTitle .Card-Primary-Action::before .useCaseDescription {
+  .useCaseDescription {
     color: v('dark-gray');
     font-size: rem(16px);
     font-style: normal;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,10 +8,8 @@ import Image from 'next/image';
 import { TEST_IDS } from '../client/testIDs';
 import { Fragment } from 'react';
 import { SEO } from '../client/components/common/seo';
-import { useRouter } from 'next/router';
 
 export default function Index() {
-  const router = useRouter();
   return (
     <>
       <SEO
@@ -35,7 +33,7 @@ export default function Index() {
       </Container>
       <div className={styles.useCaseGrid}>
         {HOMEPAGE_CARDS.map((card) => (
-          <div className={styles.useCaseCard} key={card.url} onClick={() => router.push(card.url)}>
+          <div className={styles.useCaseCard} key={card.url}>
             <div>
               <Image src={card.iconSvg} alt="" className={styles.useCaseIcon} />
               <Link className={styles.useCaseTitle} data-testid={TEST_IDS.homepageCard.useCaseTitle} href={card.url}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -35,11 +35,16 @@ export default function Index() {
         {HOMEPAGE_CARDS.map((card) => (
           <div className={styles.useCaseCard} key={card.url}>
             <div>
-              <Image src={card.iconSvg} alt="" className={styles.useCaseIcon} />
+              <Image
+                src={card.iconSvg}
+                alt=""
+                className={styles.useCaseIcon}
+                data-testid={TEST_IDS.homepageCard.useCaseIcon}
+              />
               <Link className={styles.useCaseTitle} data-testid={TEST_IDS.homepageCard.useCaseTitle} href={card.url}>
                 {card.title}
               </Link>
-              <div className={styles.useCaseDescription}>
+              <div className={styles.useCaseDescription} data-testid={TEST_IDS.homepageCard.useCaseDescription}>
                 {card.descriptionHomepage?.map((line, i) => <Fragment key={i}>{line}</Fragment>)}
               </div>
             </div>


### PR DESCRIPTION

We need to make the whole homepage cards clickable.

* But wrapping the whole card in an `<a>` element is bad for screen readers/accessibility.
* And using an `onClick` event on the card confuses Google Tag Manager triggers, it registers `click` instead of `linkClick` events.
* So this is some CSS magic to make the whole card clickable using the child `<a>` element
