### PR TITLE
Tests fix: only report JS agent network request failures

### DIFF
--- a/e2e/playground.spec.ts
+++ b/e2e/playground.spec.ts
@@ -1,6 +1,8 @@
+import { SCRIPT_URL_PATTERN } from './../src/server/const';
 import { Page, expect, test } from '@playwright/test';
 import { PLAYGROUND_TAG } from '../src/client/components/playground/playgroundTags';
 import { isAgentResponse, isServerResponse } from './zodUtils';
+import { ENDPOINT } from '../src/server/const';
 
 const getAgentResponse = async (page: Page) => {
   const agentResponse =
@@ -84,12 +86,19 @@ test.describe('Playground page', () => {
 
 test.describe('Proxy integration', () => {
   test('Proxy integration works on Playground, no network errors', async ({ page }) => {
-    // If any network request fails, fails the test
+    // If any JS agent network request fails, fails the test
     // This captures proxy integration failures that would otherwise go unnoticed thanks to default endpoint fallbacks
+    const endpointOrigin = new URL(ENDPOINT).origin;
+    const scriptUrlPatternOrigin = new URL(SCRIPT_URL_PATTERN).origin;
+
     page.on('requestfailed', (request) => {
       console.error(request.url(), request.failure()?.errorText);
-      // This fails the test
-      expect(request.failure()).toBeUndefined();
+      const requestOrigin = new URL(request.url()).origin;
+
+      if (requestOrigin === endpointOrigin || requestOrigin === scriptUrlPatternOrigin) {
+        // This fails the test
+        expect(request.failure()).toBeUndefined();
+      }
     });
 
     await page.goto('/playground');


### PR DESCRIPTION
Production e2e tests have been failing due to unrelated request failures: https://github.com/fingerprintjs/fingerprintjs-pro-use-cases/actions/runs/7902385817