### PR TITLE
fix: check origin in the event endpoint INTER-570

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
     'next/core-web-vitals',
     '@fingerprintjs/eslint-config-dx-team',
     // necessary to pickup project-specific overrides in prettierrc.js
-    'plugin:prettier/recommended',
+    'prettier',
   ],
   plugins: ['react-hooks', 'jsx-a11y'],
   rules: {

--- a/src/client/components/playground/usePlaygroundSignals.ts
+++ b/src/client/components/playground/usePlaygroundSignals.ts
@@ -23,7 +23,7 @@ export function usePlaygroundSignals() {
   } = useQuery<EventResponse | undefined>(
     [requestId],
     () =>
-      fetch(`/api/event/${agentResponse?.requestId}`).then((res) => {
+      fetch(`/api/event/${agentResponse?.requestId}`, { method: 'POST' }).then((res) => {
         if (res.status !== 200) {
           throw new Error(`${res.statusText}`);
         }


### PR DESCRIPTION
I considered using a full-blown check of IPs, timestamps, etc. just like a regular use case with `getAndValidateFingerprintResult` but given that we now have Request filtering for mobile apps turned on, I decided to just validate the origin to keep it simple for now.

Let me know if you prefer stricter checks. 