### PR TITLE
Chore: make personalization test more robust, report e2e test results INTER-320

### DIFF
--- a/.github/workflows/production_e2e.yml
+++ b/.github/workflows/production_e2e.yml
@@ -57,9 +57,11 @@ jobs:
   report-status:
     needs: e2e
     if: always()
+    # Run always for now to test it out, later we switch to on-failure only
+    # if: ${{ needs.e2e.result == 'failure' }}
     uses: fingerprintjs/dx-team-toolkit/.github/workflows/report-workflow-status.yml@v1
     with:
-      notification_title: 'Production e2e tests against demo.fingerprint.com have {status_message}'
+      notification_title: 'Production e2e tests on demo.fingerprint.com have {status_message}'
       job_status: ${{ needs.e2e.result }}
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/production_e2e.yml
+++ b/.github/workflows/production_e2e.yml
@@ -54,3 +54,12 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+  report-status:
+    needs: e2e
+    if: always()
+    uses: fingerprintjs/dx-team-toolkit/.github/workflows/report-workflow-status.yml@v1
+    with:
+      notification_title: 'Production e2e tests against demo.fingerprint.com have {status_message}'
+      job_status: ${{ needs.e2e.result }}
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/e2e/personalization.spec.ts
+++ b/e2e/personalization.spec.ts
@@ -60,6 +60,8 @@ test.describe('Personalization', () => {
 
     await product.getByTestId(PERS_ID.addToCart).click();
     await cartItem.getByTestId(CART_ID.cartItemPlusOne).click();
+    // Confirm the request was successful before reloading the page
+    await expect(cartItem.getByTestId(CART_ID.cartItemCount)).toHaveText('02');
 
     await page.reload();
 


### PR DESCRIPTION
Fix a flaky test and report E2E test results to Slack.

https://fingerprintjs.atlassian.net/browse/INTER-320

I have added the required `SLACK_WEBHOOK_URL` secret to the repository.
Let's test it like this, then we can turn the notification off for successful runs and notify just about failure. 