### PR TITLE
Fix: missing container padding

### DIFF
--- a/src/client/components/Container/Container.module.scss
+++ b/src/client/components/Container/Container.module.scss
@@ -1,6 +1,7 @@
 .container {
   --contentWidth: 920px;
-  padding: 0 unquote('max(20px, calc((100vw - (100vw - 100%))/2) - var(--contentWidth) / 2)');
+  padding-left: unquote('max(20px, calc((100vw - (100vw - 100%))/2) - var(--contentWidth) / 2)');
+  padding-right: unquote('max(20px, calc((100vw - (100vw - 100%))/2) - var(--contentWidth) / 2)');
 }
 
 .container.large {

--- a/src/server/checks.ts
+++ b/src/server/checks.ts
@@ -11,7 +11,7 @@ import { getServerRegion } from './fingerprint-server-api';
 import { IS_DEVELOPMENT } from '../envShared';
 
 export const IPv4_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.){3}(25[0-5]|(2[0-4]|1\d|[1-9]|)\d)$/;
-export const ALLOWED_REQUEST_TIMESTAMP_DIFF_MS = 4000;
+export const ALLOWED_REQUEST_TIMESTAMP_DIFF_MS = 7000;
 
 // Demo origins.
 // It is recommended to use production origins instead.


### PR DESCRIPTION
* An unexpected change in CSS rules ordering caused some Container padding styles to be overwritten. I adjusted the Container styles to prevent this.
* Ran into the `Timestamp too old` check when testing in my local environment. Does not seem to affect production but I increased the limit just in case.