### PR TITLE
fix: lock node js to v22 to fix digital ocean deployment INTER-983

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22.x'
       - name: 'Cache'
         uses: actions/cache@v4
         with:
@@ -36,7 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22.x'
       - name: 'Cache'
         uses: actions/cache@v4
         with:
@@ -60,7 +67,10 @@ jobs:
         shardTotal: [3]
     steps:
       - uses: actions/checkout@v4
-
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22.x'
       - name: Cache node modules
         uses: actions/cache@v4
         with:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:e2e:chrome": "playwright test --project='chromium'"
   },
   "engines": {
-    "node": ">=18.17.0"
+    "node": "22.x"
   },
   "dependencies": {
     "@amplitude/analytics-browser": "^2.11.5",


### PR DESCRIPTION
https://fingerprintjs.atlassian.net/browse/INTER-983 

This seems to fix the build on Digital Ocean. I'm not sure what the core of the issue is yet, but I want to restore our ability to make deployments ASAP and this should do that. 