### PR TITLE
Tag E2E traffic with FingerprintBot user agent

### DIFF
--- a/e2e/fingerprintBotUserAgent.ts
+++ b/e2e/fingerprintBotUserAgent.ts
@@ -1,0 +1,6 @@
+/**
+ * Identify our own E2E test traffic with a dedicated bot user agent, so it can be
+ * recognized as first-party traffic instead of polluting third-party bot detection analytics.
+ */
+export const FINGERPRINT_BOT_USER_AGENT =
+  'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; FingerprintBot/1.0; +https://fingerprint.com/fingerprint-bot';

--- a/e2e/user-agent.spec.ts
+++ b/e2e/user-agent.spec.ts
@@ -1,0 +1,6 @@
+import { expect, test } from '@playwright/test';
+import { FINGERPRINT_BOT_USER_AGENT } from './fingerprintBotUserAgent';
+
+test('uses FingerprintBot user agent', async ({ page }) => {
+  expect(await page.evaluate(() => navigator.userAgent)).toBe(FINGERPRINT_BOT_USER_AGENT);
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,6 +15,14 @@ const E2E_TEST_PASSWORD_HEADER = process.env.E2E_TEST_PASSWORD_HEADER;
 const VIEWPORT = { width: 1280, height: 800 };
 
 /**
+ * Identify our own E2E test traffic with a dedicated bot user agent, so it can be
+ * recognized as first-party traffic instead of polluting third-party bot detection analytics.
+ * See https://fingerprintjs.slack.com/archives/C02P7D7TCS3/p1785783943800919
+ */
+const FINGERPRINT_BOT_USER_AGENT =
+  'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; FingerprintBot/1.0; +https://fingerprint.com/fingerprint-bot';
+
+/**
  * @see https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({
@@ -79,6 +87,7 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
         viewport: VIEWPORT,
         permissions: ['clipboard-read'],
+        userAgent: FINGERPRINT_BOT_USER_AGENT,
       },
     },
     {
@@ -86,6 +95,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Firefox'],
         viewport: VIEWPORT,
+        userAgent: FINGERPRINT_BOT_USER_AGENT,
         // Firefox is extra secure, so you need to enable clipboard read permission like this
         // https://github.com/microsoft/playwright/issues/13037#issuecomment-1739856724
         launchOptions: {
@@ -101,6 +111,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Safari'],
         viewport: VIEWPORT,
+        userAgent: FINGERPRINT_BOT_USER_AGENT,
       },
 
       // Webkit cannot read the clipboard at all, skip that part of the tests for webkit

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,7 @@ import { defineConfig, devices } from '@playwright/test';
  * https://github.com/motdotla/dotenv
  */
 import 'dotenv/config';
+import { FINGERPRINT_BOT_USER_AGENT } from './e2e/fingerprintBotUserAgent';
 import { PRODUCTION_E2E_TEST_BASE_URL } from './src/envShared';
 
 const IS_CI = Boolean(process.env.CI);
@@ -13,14 +14,6 @@ const E2E_TEST_PASSWORD_HEADER = process.env.E2E_TEST_PASSWORD_HEADER;
 
 // Use a more square/vertical viewport to make sure important elements are visible in test report screenshots/videos
 const VIEWPORT = { width: 1280, height: 800 };
-
-/**
- * Identify our own E2E test traffic with a dedicated bot user agent, so it can be
- * recognized as first-party traffic instead of polluting third-party bot detection analytics.
- */
-const FINGERPRINT_BOT_USER_AGENT =
-  'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; FingerprintBot/1.0; +https://fingerprint.com/fingerprint-bot';
-
 /**
  * @see https://playwright.dev/docs/test-configuration
  */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,6 @@ const VIEWPORT = { width: 1280, height: 800 };
 /**
  * Identify our own E2E test traffic with a dedicated bot user agent, so it can be
  * recognized as first-party traffic instead of polluting third-party bot detection analytics.
- * See https://fingerprintjs.slack.com/archives/C02P7D7TCS3/p1785783943800919
  */
 const FINGERPRINT_BOT_USER_AGENT =
   'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; FingerprintBot/1.0; +https://fingerprint.com/fingerprint-bot';


### PR DESCRIPTION
- Set a dedicated `FingerprintBot/1.0` user agent in Playwright so production E2E traffic is identifiable in bot analytics