### PR TITLE
Split Proxy Detection out of IP Blocklist smart signal on Playground

### DIFF
--- a/e2e/playground.spec.ts
+++ b/e2e/playground.spec.ts
@@ -59,6 +59,7 @@ test.describe('Playground page', () => {
     await page.getByText('VPN', { exact: true }).waitFor();
 
     await page.getByText('IP Blocklist', { exact: true }).waitFor();
+    await page.getByText('Proxy Detection', { exact: true }).waitFor();
     await page.getByText('Emulator', { exact: true }).waitFor();
     await page.getByText('iOS Simulator', { exact: true }).waitFor();
     await page.getByText('Proximity Detection', { exact: true }).waitFor();

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@amplitude/analytics-browser": "^2.11.5",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",
-    "@fingerprint/node-sdk": "^7.0.0",
+    "@fingerprint/node-sdk": "^7.7.0",
     "@fingerprint/react": "^3.0.0",
     "@fingerprintjs/fingerprintjs-pro-server-api": "^6.10.0",
     "@inkeep/cxkit-react": "^0.5.107",

--- a/src/app/playground/Playground.tsx
+++ b/src/app/playground/Playground.tsx
@@ -7,6 +7,7 @@ import SignalTable, { TableCellData } from './components/SignalTable';
 import botDetectionResult from './components/BotDetectionResult';
 import { RefreshButton } from './components/RefreshButton';
 import { ipBlocklistResult } from './components/IpBlocklistResult';
+import { proxyDetectionResult } from './components/ProxyDetectionResult';
 import { vpnDetectionResult } from './components/VpnDetectionResult';
 import { usePlaygroundSignals } from './hooks/usePlaygroundSignals';
 import { getLocationName, getZoomLevel } from '../../utils/locationUtils';
@@ -382,10 +383,25 @@ export function Playground() {
         className:
           identificationEvent?.ip_blocklist?.attack_source ||
           identificationEvent?.ip_blocklist?.email_spam ||
-          identificationEvent?.ip_blocklist?.tor_node ||
-          identificationEvent?.proxy
+          identificationEvent?.ip_blocklist?.tor_node
             ? tableStyles.red
             : tableStyles.green,
+      },
+    ],
+    [
+      {
+        content: [
+          <DocsLink
+            href='https://dev.fingerprint.com/docs/smart-signals-reference#proxy-detection'
+            key='proxy-detection'
+          >
+            Proxy Detection
+          </DocsLink>,
+        ],
+      },
+      {
+        content: <JsonLink propertyName='proxy'>{proxyDetectionResult({ event: identificationEvent })}</JsonLink>,
+        className: identificationEvent?.proxy === true ? tableStyles.red : tableStyles.green,
       },
     ],
     [

--- a/src/app/playground/components/IpBlocklistResult.tsx
+++ b/src/app/playground/components/IpBlocklistResult.tsx
@@ -14,10 +14,6 @@ export const ipBlocklistResult = ({ event }: { event: Event | undefined }): stri
   if (blocklistData?.tor_node === true) {
     return 'Your IP is a Tor exit node 🧅';
   }
-  if (event?.proxy === true) {
-    const proxyType = event.proxy_details?.proxy_type ?? 'unknown';
-    return `Your IP is used by a ${proxyType} proxy provider 🔄`;
-  }
   // If we reach here, nothing was detected
   return 'Not detected';
 };

--- a/src/app/playground/components/ProxyDetectionResult.tsx
+++ b/src/app/playground/components/ProxyDetectionResult.tsx
@@ -14,8 +14,8 @@ export const proxyDetectionResult = ({ event }: { event: Event | undefined }): s
   const providerText = details?.provider ? ` from ${details.provider}` : '';
 
   if (details?.proxy_type === 'residential' || details?.proxy_type === 'data_center') {
-    return `Your IP is used by a ${details.proxy_type.replaceAll('_', ' ')} proxy${providerText} 🔄${extrasText}`;
+    return `Your IP is used by a ${details.proxy_type.replaceAll('_', ' ')} proxy${providerText}${extrasText}`;
   }
 
-  return `Proxy detected 🔄${extrasText}`;
+  return `Proxy detected${extrasText}`;
 };

--- a/src/app/playground/components/ProxyDetectionResult.tsx
+++ b/src/app/playground/components/ProxyDetectionResult.tsx
@@ -4,9 +4,19 @@ export const proxyDetectionResult = ({ event }: { event: Event | undefined }): s
   if (event?.proxy !== true) {
     return 'Not detected';
   }
+
   const details = event.proxy_details;
-  const typeText = details?.proxy_type ? `${details.proxy_type.replace('_', ' ')} ` : '';
+  const proxyType = details?.proxy_type;
+  // Docs also return "unknown" for ML-only detections (not in current SDK types).
+  // https://dev.fingerprint.com/docs/smart-signals-reference#proxy-detection
+  const typeLabel =
+    proxyType === 'residential' || proxyType === 'data_center' ? proxyType.replaceAll('_', ' ') : undefined;
   const providerText = details?.provider ? ` from ${details.provider}` : '';
   const confidenceText = event.proxy_confidence ? ` (confidence: ${event.proxy_confidence})` : '';
-  return `Your IP is used by a ${typeText}proxy provider${providerText} 🔄${confidenceText}`;
+
+  if (!typeLabel) {
+    return `Proxy detected 🔄${confidenceText}`;
+  }
+
+  return `Your IP is used by a ${typeLabel} proxy${providerText} 🔄${confidenceText}`;
 };

--- a/src/app/playground/components/ProxyDetectionResult.tsx
+++ b/src/app/playground/components/ProxyDetectionResult.tsx
@@ -4,6 +4,9 @@ export const proxyDetectionResult = ({ event }: { event: Event | undefined }): s
   if (event?.proxy !== true) {
     return 'Not detected';
   }
-  const proxyType = event.proxy_details?.proxy_type ?? 'unknown';
-  return `Your IP is used by a ${proxyType} proxy provider 🔄`;
+  const details = event.proxy_details;
+  const typeText = details?.proxy_type ? `${details.proxy_type.replace('_', ' ')} ` : '';
+  const providerText = details?.provider ? ` from ${details.provider}` : '';
+  const confidenceText = event.proxy_confidence ? ` (confidence: ${event.proxy_confidence})` : '';
+  return `Your IP is used by a ${typeText}proxy provider${providerText} 🔄${confidenceText}`;
 };

--- a/src/app/playground/components/ProxyDetectionResult.tsx
+++ b/src/app/playground/components/ProxyDetectionResult.tsx
@@ -6,17 +6,16 @@ export const proxyDetectionResult = ({ event }: { event: Event | undefined }): s
   }
 
   const details = event.proxy_details;
-  const proxyType = details?.proxy_type;
-  // Docs also return "unknown" for ML-only detections (not in current SDK types).
-  // https://dev.fingerprint.com/docs/smart-signals-reference#proxy-detection
-  const typeLabel =
-    proxyType === 'residential' || proxyType === 'data_center' ? proxyType.replaceAll('_', ' ') : undefined;
+  const extras = [
+    event.proxy_confidence ? `confidence: ${event.proxy_confidence}` : undefined,
+    event.proxy_ml_score != null ? `ML score: ${event.proxy_ml_score}` : undefined,
+  ].filter(Boolean);
+  const extrasText = extras.length > 0 ? ` (${extras.join(', ')})` : '';
   const providerText = details?.provider ? ` from ${details.provider}` : '';
-  const confidenceText = event.proxy_confidence ? ` (confidence: ${event.proxy_confidence})` : '';
 
-  if (!typeLabel) {
-    return `Proxy detected 🔄${confidenceText}`;
+  if (details?.proxy_type === 'residential' || details?.proxy_type === 'data_center') {
+    return `Your IP is used by a ${details.proxy_type.replaceAll('_', ' ')} proxy${providerText} 🔄${extrasText}`;
   }
 
-  return `Your IP is used by a ${typeLabel} proxy${providerText} 🔄${confidenceText}`;
+  return `Proxy detected 🔄${extrasText}`;
 };

--- a/src/app/playground/components/ProxyDetectionResult.tsx
+++ b/src/app/playground/components/ProxyDetectionResult.tsx
@@ -1,0 +1,9 @@
+import { Event } from '@fingerprint/node-sdk';
+
+export const proxyDetectionResult = ({ event }: { event: Event | undefined }): string => {
+  if (event?.proxy !== true) {
+    return 'Not detected';
+  }
+  const proxyType = event.proxy_details?.proxy_type ?? 'unknown';
+  return `Your IP is used by a ${proxyType} proxy provider 🔄`;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,10 +988,10 @@
   resolved "https://registry.yarnpkg.com/@fingerprint/agent/-/agent-4.0.0.tgz#e046103297ab5385f1f3b6f4ddf8c53971a10ed0"
   integrity sha512-GdFdBeaDqLc3hVQLcxPwckk+1217raR/ouxBkGXSykxAswl1xxrt6GLaR93cKY8ehjp7ZFYSjSu4aLKUesgvIg==
 
-"@fingerprint/node-sdk@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@fingerprint/node-sdk/-/node-sdk-7.0.0.tgz#7ebc564a3020a5036372444a7f36f010e6a18b7f"
-  integrity sha512-v+8A+hZacJNn5hFj5HHKabm76IpLbRULnY5Jc0JTTsjsRyxiXN9YGYGPYMNGBpqPACtLWAs/yK2WlnGt9+6I4w==
+"@fingerprint/node-sdk@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@fingerprint/node-sdk/-/node-sdk-7.7.0.tgz#7e00f0c551f53f2aa327c2890c034dad24bef153"
+  integrity sha512-7FjFJpI4CoV/alS3fGvR6yBo89eSG2jkQOrhHM9CPqgzEYglU2pBdJbQALcJOw7hmJItdV4ozj4+Tx1+lFHpPQ==
 
 "@fingerprint/react@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
- Split Proxy Detection into its own Playground row so it matches the current smart signals API. IP Blocklist is only `email_spam` / `attack_source` / `tor_node`.
- Bump `@fingerprint/node-sdk` to 7.7.0. The row now shows `proxy_type: unknown` and `proxy_ml_score` when present.

<img width="679" height="480" alt="image" src="https://github.com/user-attachments/assets/df09430a-dd56-43a5-9ffe-c0c610f5fcfc" />
