### PR TITLE
Fix nested links in paywall article cards

### DIFF
--- a/src/app/paywall/components/ArticleGrid.tsx
+++ b/src/app/paywall/components/ArticleGrid.tsx
@@ -52,9 +52,7 @@ export const ArticleCard: FunctionComponent<ArticleCardProps> = ({ article, embe
       <Image src={article.image} alt='' className={styles.articleCardImage} sizes='100vw' />
       <div className={styles.articleCardContent}>
         <Byline article={article} />
-        <a href={link} key={article.id} className={styles.articleCardTitle}>
-          {article.title}
-        </a>
+        <div className={styles.articleCardTitle}>{article.title}</div>
         <p className={styles.articleCardDescription}>{article.description}</p>
         <div className={styles.articleCardTags}>
           {article.tags.map((tag) => (


### PR DESCRIPTION
- Remove the extra title `<a>` inside paywall `ArticleCard`. The whole card is already a Next.js `Link`, and nested anchors cause a hydration error.

### Test plan
- [x] Open `/paywall` and confirm the nested-`<a>` hydration error is gone
- [x] Click the hero card and a grid card, then a related article on the article page
- [x] Repeat on `/paywall/embed`