### PR TITLE
ci: ping Juraj when production e2e tests fail

### DIFF
--- a/.github/workflows/production_e2e.yml
+++ b/.github/workflows/production_e2e.yml
@@ -71,12 +71,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Report Status
-        # Incoming webhooks render <@id> but do not notify. chat.postMessage does.
-        # https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks
+        # Incoming webhooks only notify if <@id> is in top-level text, not attachments.
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
-            channel: C042EFTCAPJ
             text: "<@U04GNKK5ZTQ> Production e2e tests on demo.fingerprint.com have failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/production_e2e.yml
+++ b/.github/workflows/production_e2e.yml
@@ -68,9 +68,16 @@ jobs:
   report-status:
     needs: e2e-prod
     if: failure()
-    uses: fingerprintjs/dx-team-toolkit/.github/workflows/report-workflow-status.yml@v1
-    with:
-      notification_title: 'Hey, <@U04GNKK5ZTQ>! Production e2e tests on demo.fingerprint.com have {status_message}'
-      job_status: ${{ needs.e2e.result }}
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report Status
+        # mention_users puts <@id> in attachment text (the only field with mrkdwn).
+        # Putting the mention in notification_title lands in pretext and does not ping.
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
+        with:
+          status: ${{ needs.e2e-prod.result }}
+          notification_title: 'Production e2e tests on demo.fingerprint.com have {status_message}'
+          mention_users: 'U04GNKK5ZTQ'
+          mention_users_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/production_e2e.yml
+++ b/.github/workflows/production_e2e.yml
@@ -77,4 +77,4 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            text: "<@U04GNKK5ZTQ> Production e2e tests on demo.fingerprint.com have failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+            text: ":x: :x: :x: <@U04GNKK5ZTQ> Production e2e tests on demo.fingerprint.com have failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/production_e2e.yml
+++ b/.github/workflows/production_e2e.yml
@@ -71,13 +71,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Report Status
-        # mention_users puts <@id> in attachment text (the only field with mrkdwn).
-        # Putting the mention in notification_title lands in pretext and does not ping.
-        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2
+        # Incoming webhooks render <@id> but do not notify. chat.postMessage does.
+        # https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
-          status: ${{ needs.e2e-prod.result }}
-          notification_title: 'Production e2e tests on demo.fingerprint.com have {status_message}'
-          mention_users: 'U04GNKK5ZTQ'
-          mention_users_when: 'failure'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: C042EFTCAPJ
+            text: "<@U04GNKK5ZTQ> Production e2e tests on demo.fingerprint.com have failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"


### PR DESCRIPTION
- Tag Juraj on production e2e Slack failures via the existing incoming webhook.

### What we learned

Incoming webhooks render `<@user>` in attachments without sending a notification. The same mention in top-level `text` does ping. `notify-slack-action` only writes attachments (`notification_title` → pretext, `mention_users` → attachment text), so it could never notify.