### PR TITLE
INTER-2486: Redact eventId and visitorId from public bot-visits

### DIFF
--- a/src/app/bot-firewall/BotFirewall.tsx
+++ b/src/app/bot-firewall/BotFirewall.tsx
@@ -15,7 +15,7 @@ import { FunctionComponent, useState } from 'react';
 import { wait } from '../../utils/timeUtils';
 import { Spinner } from '../../client/components/Spinner/Spinner';
 import { Alert } from '../../client/components/Alert/Alert';
-import { PublicBotVisit } from './api/get-bot-visits/botVisitDatabase';
+import { BotVisit } from './api/get-bot-visits/botVisitDatabase';
 import { BotTypeInfo, BotVisitAction, InstructionPrompt } from './components/botFirewallComponents';
 import { FPJS_CLIENT_TIMEOUT } from '../../const';
 import { useEventsGetResponse } from '../../client/hooks/useEventsGetResponse';
@@ -47,7 +47,7 @@ const useBotVisits = () => {
     status: botVisitsQueryStatus,
   } = useQuery({
     queryKey: ['get bot visits'],
-    queryFn: async (): Promise<PublicBotVisit[]> => {
+    queryFn: async (): Promise<BotVisit[]> => {
       const res = await fetch(`/bot-firewall/api/get-bot-visits?limit=${BOT_VISITS_FETCH_LIMIT}`);
       return await res.json();
     },
@@ -169,6 +169,7 @@ export const BotFirewall: FunctionComponent<{ embed?: boolean }> = ({ embed }) =
               <th>
                 Timestamp <Image src={ChevronIcon} alt='' />
               </th>
+              <th>Request ID</th>
               <th>
                 Bot Type <BotTypeInfo />
               </th>
@@ -181,6 +182,7 @@ export const BotFirewall: FunctionComponent<{ embed?: boolean }> = ({ embed }) =
               return (
                 <tr key={botVisit.id}>
                   <td>{formatDate(botVisit.timestamp)}</td>
+                  <td>{botVisit.eventId}</td>
                   <td>
                     {botVisit.botResult} ({botVisit.botType})
                   </td>
@@ -208,6 +210,9 @@ export const BotFirewall: FunctionComponent<{ embed?: boolean }> = ({ embed }) =
                 <div className={styles.cardContent}>
                   <div>Timestamp</div>
                   <div>{formatDate(botVisit.timestamp)}</div>
+
+                  <div>Event ID</div>
+                  <div>{botVisit.eventId}</div>
 
                   <div>
                     Bot Type <BotTypeInfo />

--- a/src/app/bot-firewall/BotFirewall.tsx
+++ b/src/app/bot-firewall/BotFirewall.tsx
@@ -15,7 +15,7 @@ import { FunctionComponent, useState } from 'react';
 import { wait } from '../../utils/timeUtils';
 import { Spinner } from '../../client/components/Spinner/Spinner';
 import { Alert } from '../../client/components/Alert/Alert';
-import { BotVisit } from './api/get-bot-visits/botVisitDatabase';
+import { PublicBotVisit } from './api/get-bot-visits/botVisitDatabase';
 import { BotTypeInfo, BotVisitAction, InstructionPrompt } from './components/botFirewallComponents';
 import { FPJS_CLIENT_TIMEOUT } from '../../const';
 import { useEventsGetResponse } from '../../client/hooks/useEventsGetResponse';
@@ -47,7 +47,7 @@ const useBotVisits = () => {
     status: botVisitsQueryStatus,
   } = useQuery({
     queryKey: ['get bot visits'],
-    queryFn: async (): Promise<BotVisit[]> => {
+    queryFn: async (): Promise<PublicBotVisit[]> => {
       const res = await fetch(`/bot-firewall/api/get-bot-visits?limit=${BOT_VISITS_FETCH_LIMIT}`);
       return await res.json();
     },
@@ -169,7 +169,6 @@ export const BotFirewall: FunctionComponent<{ embed?: boolean }> = ({ embed }) =
               <th>
                 Timestamp <Image src={ChevronIcon} alt='' />
               </th>
-              <th>Request ID</th>
               <th>
                 Bot Type <BotTypeInfo />
               </th>
@@ -180,9 +179,8 @@ export const BotFirewall: FunctionComponent<{ embed?: boolean }> = ({ embed }) =
           <tbody>
             {botVisits.slice(0, displayedVisits).map((botVisit) => {
               return (
-                <tr key={botVisit.eventId}>
+                <tr key={botVisit.id}>
                   <td>{formatDate(botVisit.timestamp)}</td>
-                  <td>{botVisit.eventId}</td>
                   <td>
                     {botVisit.botResult} ({botVisit.botType})
                   </td>
@@ -206,13 +204,10 @@ export const BotFirewall: FunctionComponent<{ embed?: boolean }> = ({ embed }) =
         <div className={styles.cards}>
           {botVisits.slice(0, displayedVisits).map((botVisit) => {
             return (
-              <div key={botVisit.eventId} className={styles.card}>
+              <div key={botVisit.id} className={styles.card}>
                 <div className={styles.cardContent}>
                   <div>Timestamp</div>
                   <div>{formatDate(botVisit.timestamp)}</div>
-
-                  <div>Event ID</div>
-                  <div>{botVisit.eventId}</div>
 
                   <div>
                     Bot Type <BotTypeInfo />

--- a/src/app/bot-firewall/api/get-bot-visits/botVisitDatabase.ts
+++ b/src/app/bot-firewall/api/get-bot-visits/botVisitDatabase.ts
@@ -9,6 +9,7 @@ import {
 } from 'sequelize';
 import { sequelize } from '../../../../server/sequelize';
 import { Event } from '@fingerprint/node-sdk';
+import { redactId } from './redactId';
 
 interface BotVisitAttributes
   extends Model<InferAttributes<BotVisitAttributes>, InferCreationAttributes<BotVisitAttributes>> {
@@ -59,9 +60,6 @@ BotVisitDbModel.sync({ force: false });
 
 export type BotVisit = Attributes<BotVisitAttributes>;
 
-/** Public bot-visit row. Omits eventId and visitorId so the unauthenticated list cannot be used to impersonate visitors. */
-export type PublicBotVisit = Pick<BotVisit, 'id' | 'ip' | 'timestamp' | 'botResult' | 'botType'>;
-
 export const saveBotVisit = async (eventData: Event, visitorId: string) => {
   BotVisitDbModel.create({
     ip: eventData.ip_address ?? '',
@@ -75,20 +73,20 @@ export const saveBotVisit = async (eventData: Event, visitorId: string) => {
   });
 };
 
-export const getBotVisits = async (limit?: number): Promise<PublicBotVisit[]> => {
+export const getBotVisits = async (limit?: number): Promise<BotVisit[]> => {
   const options: FindOptions = {
     order: [['timestamp', 'DESC']],
-    attributes: ['id', 'ip', 'timestamp', 'botResult', 'botType'],
   };
   if (limit) {
     options.limit = limit;
   }
   const rows = await BotVisitDbModel.findAll(options);
-  return rows.map((row) => ({
-    id: row.id,
-    ip: row.ip,
-    timestamp: row.timestamp,
-    botResult: row.botResult,
-    botType: row.botType,
-  }));
+  return rows.map((row) => {
+    const visit = row.get({ plain: true });
+    return {
+      ...visit,
+      eventId: redactId(visit.eventId),
+      visitorId: redactId(visit.visitorId),
+    };
+  });
 };

--- a/src/app/bot-firewall/api/get-bot-visits/botVisitDatabase.ts
+++ b/src/app/bot-firewall/api/get-bot-visits/botVisitDatabase.ts
@@ -1,9 +1,18 @@
-import { Attributes, DataTypes, FindOptions, InferAttributes, InferCreationAttributes, Model } from 'sequelize';
+import {
+  Attributes,
+  CreationOptional,
+  DataTypes,
+  FindOptions,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+} from 'sequelize';
 import { sequelize } from '../../../../server/sequelize';
 import { Event } from '@fingerprint/node-sdk';
 
 interface BotVisitAttributes
   extends Model<InferAttributes<BotVisitAttributes>, InferCreationAttributes<BotVisitAttributes>> {
+  id: CreationOptional<number>;
   visitorId: string;
   eventId: string;
   ip: string;
@@ -15,6 +24,11 @@ interface BotVisitAttributes
 }
 
 const BotVisitDbModel = sequelize.define<BotVisitAttributes>('bot_visits', {
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true,
+  },
   visitorId: {
     type: DataTypes.STRING,
   },
@@ -45,6 +59,9 @@ BotVisitDbModel.sync({ force: false });
 
 export type BotVisit = Attributes<BotVisitAttributes>;
 
+/** Public bot-visit row. Omits eventId and visitorId so the unauthenticated list cannot be used to impersonate visitors. */
+export type PublicBotVisit = Pick<BotVisit, 'id' | 'ip' | 'timestamp' | 'botResult' | 'botType'>;
+
 export const saveBotVisit = async (eventData: Event, visitorId: string) => {
   BotVisitDbModel.create({
     ip: eventData.ip_address ?? '',
@@ -58,12 +75,20 @@ export const saveBotVisit = async (eventData: Event, visitorId: string) => {
   });
 };
 
-export const getBotVisits = async (limit?: number) => {
+export const getBotVisits = async (limit?: number): Promise<PublicBotVisit[]> => {
   const options: FindOptions = {
     order: [['timestamp', 'DESC']],
+    attributes: ['id', 'ip', 'timestamp', 'botResult', 'botType'],
   };
   if (limit) {
     options.limit = limit;
   }
-  return await BotVisitDbModel.findAll(options);
+  const rows = await BotVisitDbModel.findAll(options);
+  return rows.map((row) => ({
+    id: row.id,
+    ip: row.ip,
+    timestamp: row.timestamp,
+    botResult: row.botResult,
+    botType: row.botType,
+  }));
 };

--- a/src/app/bot-firewall/api/get-bot-visits/redactId.test.ts
+++ b/src/app/bot-firewall/api/get-bot-visits/redactId.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { redactId } from './redactId';
+
+describe('redactId', () => {
+  it('replaces the last three characters', () => {
+    expect(redactId('1772193689839.s9OOvM')).toBe('1772193689839.s9O***');
+    expect(redactId('s2OaKGP53ef8105Hwgq3')).toBe('s2OaKGP53ef8105Hw***');
+  });
+
+  it('redacts the whole value when it is three characters or shorter', () => {
+    expect(redactId('ab')).toBe('**');
+    expect(redactId('abc')).toBe('***');
+  });
+});

--- a/src/app/bot-firewall/api/get-bot-visits/redactId.test.ts
+++ b/src/app/bot-firewall/api/get-bot-visits/redactId.test.ts
@@ -8,6 +8,9 @@ describe('redactId', () => {
   });
 
   it('redacts the whole value when it is three characters or shorter', () => {
+    expect(redactId('')).toBe('');
+    expect(redactId(null)).toBe('');
+    expect(redactId(undefined)).toBe('');
     expect(redactId('ab')).toBe('**');
     expect(redactId('abc')).toBe('***');
   });

--- a/src/app/bot-firewall/api/get-bot-visits/redactId.test.ts
+++ b/src/app/bot-firewall/api/get-bot-visits/redactId.test.ts
@@ -4,7 +4,7 @@ import { redactId } from './redactId';
 describe('redactId', () => {
   it('replaces the last three characters', () => {
     expect(redactId('1772193689839.s9OOvM')).toBe('1772193689839.s9O***');
-    expect(redactId('s2OaKGP53ef8105Hwgq3')).toBe('s2OaKGP53ef8105Hw***');
+    expect(redactId('abcdefghijklmnopqrst')).toBe('abcdefghijklmnopq***');
   });
 
   it('redacts the whole value when it is three characters or shorter', () => {

--- a/src/app/bot-firewall/api/get-bot-visits/redactId.ts
+++ b/src/app/bot-firewall/api/get-bot-visits/redactId.ts
@@ -1,6 +1,6 @@
 const REDACT_LENGTH = 3;
 
-/** Hide the last 3 characters so the ID can be found in the dashboard but not replayed. */
+/** Hide the last `REDACT_LENGTH` characters so the ID can be found in the dashboard but not replayed. */
 export function redactId(id: string): string {
   if (id.length <= REDACT_LENGTH) {
     return '*'.repeat(id.length);

--- a/src/app/bot-firewall/api/get-bot-visits/redactId.ts
+++ b/src/app/bot-firewall/api/get-bot-visits/redactId.ts
@@ -1,0 +1,9 @@
+const REDACT_LENGTH = 3;
+
+/** Hide the last 3 characters so the ID can be found in the dashboard but not replayed. */
+export function redactId(id: string): string {
+  if (id.length <= REDACT_LENGTH) {
+    return '*'.repeat(id.length);
+  }
+  return `${id.slice(0, -REDACT_LENGTH)}${'*'.repeat(REDACT_LENGTH)}`;
+}

--- a/src/app/bot-firewall/api/get-bot-visits/redactId.ts
+++ b/src/app/bot-firewall/api/get-bot-visits/redactId.ts
@@ -1,7 +1,10 @@
 const REDACT_LENGTH = 3;
 
 /** Hide the last `REDACT_LENGTH` characters so the ID can be found in the dashboard but not replayed. */
-export function redactId(id: string): string {
+export function redactId(id: string | null | undefined): string {
+  if (!id) {
+    return '';
+  }
   if (id.length <= REDACT_LENGTH) {
     return '*'.repeat(id.length);
   }

--- a/src/app/bot-firewall/api/get-bot-visits/route.ts
+++ b/src/app/bot-firewall/api/get-bot-visits/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { BotVisit, getBotVisits } from './botVisitDatabase';
+import { getBotVisits, PublicBotVisit } from './botVisitDatabase';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(req: NextRequest): Promise<NextResponse<BotVisit[]>> {
+export async function GET(req: NextRequest): Promise<NextResponse<PublicBotVisit[]>> {
   try {
     const searchParams = req.nextUrl.searchParams;
     const limit = searchParams.get('limit');

--- a/src/app/bot-firewall/api/get-bot-visits/route.ts
+++ b/src/app/bot-firewall/api/get-bot-visits/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getBotVisits, PublicBotVisit } from './botVisitDatabase';
+import { BotVisit, getBotVisits } from './botVisitDatabase';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET(req: NextRequest): Promise<NextResponse<PublicBotVisit[]>> {
+export async function GET(req: NextRequest): Promise<NextResponse<BotVisit[]>> {
   try {
     const searchParams = req.nextUrl.searchParams;
     const limit = searchParams.get('limit');


### PR DESCRIPTION
- Redact the last 3 characters of `eventId` and `visitorId` on the unauthenticated bot-visits API so the IDs can still be found in the dashboard but cannot be replayed.
- Keep the Request ID / Event ID columns in the Bot Firewall UI.

### Stacking

Independent of [#241](https://github.com/fingerprintjs/fingerprintjs-pro-use-cases/pull/241) (trusted client IP). Either can merge first.