### PR TITLE
fix: remove Google Analytics `_gl` linker param from the URL (INTER-1341)

### DIFF
--- a/e2e/googleLinkerParam.spec.ts
+++ b/e2e/googleLinkerParam.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+import { blockGoogleTagManager } from './e2eTestUtils';
+
+const GL_VALUE = '1*1abc2de*_ga*MTIzNDU2Nzg5LjE3NTI2ODEyMzQ.*_ga_ABCDEF1234*czE3NTI2ODEyMzQkbzEkZzAkajYw';
+
+/**
+ * Waiting for the Google tag to settle takes an identification round trip, which is more
+ * than the default `expect` timeout allows for.
+ */
+const REMOVAL_TIMEOUT = 20000;
+
+test.beforeEach(async ({ page }) => {
+  await blockGoogleTagManager(page);
+});
+
+test.describe('Google Analytics linker parameter', () => {
+  test('is removed from the URL after the page loads', async ({ page }) => {
+    await page.goto(`/?${new URLSearchParams({ _gl: GL_VALUE })}`);
+
+    await expect(page).toHaveURL('/', { timeout: REMOVAL_TIMEOUT });
+  });
+
+  test('is removed from a use case URL without dropping the other query parameters', async ({ page }) => {
+    await page.goto(`/paywall?${new URLSearchParams({ _gl: GL_VALUE, utm_source: 'blog' })}`);
+
+    await expect(page).toHaveURL('/paywall?utm_source=blog', { timeout: REMOVAL_TIMEOUT });
+  });
+});

--- a/src/client/thirdParty/Gtm.tsx
+++ b/src/client/thirdParty/Gtm.tsx
@@ -1,19 +1,38 @@
 import Script from 'next/script';
 
-export const GoogleTagManager = ({ gtmId }: { gtmId: string }) => {
+type GoogleTagManagerProps = {
+  gtmId: string;
+  /** Called once the container has loaded, or failed to load (blocked by an ad blocker, offline, ...). */
+  onSettled?: () => void;
+};
+
+export const GoogleTagManager = ({ gtmId, onSettled }: GoogleTagManagerProps) => {
   return (
-    <Script
-      id='gtag-base'
-      strategy='afterInteractive'
-      dangerouslySetInnerHTML={{
-        __html: `
-                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-                j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-                'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-                })(window,document,'script','dataLayer', '${gtmId}');
+    <>
+      <Script
+        id='gtm-data-layer'
+        strategy='afterInteractive'
+        dangerouslySetInnerHTML={{
+          __html: `
+                window.dataLayer = window.dataLayer || [];
+                window.dataLayer.push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
               `,
-      }}
-    />
+        }}
+      />
+      {/*
+        The container is loaded with `next/script` rather than with the `document.createElement` call from
+        Google's own snippet (this is also what `@next/third-parties` does). That way we get a reliable
+        `onLoad`, which we need to know when the Google tag has read the `_gl` linker parameter off the URL.
+        `next/script` never fires `onLoad` for inline scripts, and the inline snippet would in any case report
+        itself as loaded before the container it injects had a chance to run.
+      */}
+      <Script
+        id='gtm-base'
+        strategy='afterInteractive'
+        src={`https://www.googletagmanager.com/gtm.js?id=${encodeURIComponent(gtmId)}`}
+        onLoad={onSettled}
+        onError={onSettled}
+      />
+    </>
   );
 };

--- a/src/client/thirdParty/ThirdPartyIntegrations.tsx
+++ b/src/client/thirdParty/ThirdPartyIntegrations.tsx
@@ -10,9 +10,10 @@ import { env } from '../../env';
 
 import { GoogleTagManager } from './Gtm';
 import { Amplitude } from './Amplitude';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { InkeepChatButton } from './Inkeep';
 import { usePlaygroundSignals } from '../../app/playground/hooks/usePlaygroundSignals';
+import { useRemoveGoogleLinkerParam } from './googleLinkerParam';
 
 // GTM API requires dataLayer access through global window variable
 declare global {
@@ -37,13 +38,23 @@ export const ThirdPartyIntegrations = () => {
     enableAnalytics();
   }, []);
 
-  const { identificationEvent } = usePlaygroundSignals();
+  const { identificationEvent, agentError, serverError } = usePlaygroundSignals();
   const isNotBot =
     identificationEvent && identificationEvent.bot === 'not_detected' && identificationEvent.virtual_machine === false;
 
+  const [hasGoogleTagSettled, setHasGoogleTagSettled] = useState(false);
+  /**
+   * The Google tag only renders once we know the visitor is not a bot, so until identification is done it might
+   * still be on its way. Once identification is done (or has failed) and the visitor turns out to be a bot, or when
+   * this deployment has no container configured at all, no Google tag is ever going to read the linker parameter.
+   */
+  const isIdentificationDone = Boolean(identificationEvent || agentError || serverError);
+  const willGoogleTagNeverLoad = !GTM_ID || (isIdentificationDone && !isNotBot);
+  useRemoveGoogleLinkerParam(hasGoogleTagSettled || willGoogleTagNeverLoad);
+
   return (
     <>
-      {GTM_ID && isNotBot ? <GoogleTagManager gtmId={GTM_ID} /> : null}
+      {GTM_ID && isNotBot ? <GoogleTagManager gtmId={GTM_ID} onSettled={() => setHasGoogleTagSettled(true)} /> : null}
       {AMPLITUDE_API_KEY ? <Amplitude apiKey={AMPLITUDE_API_KEY} /> : null}
       <InkeepChatButton />
     </>

--- a/src/client/thirdParty/googleLinkerParam.test.ts
+++ b/src/client/thirdParty/googleLinkerParam.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { urlWithoutGoogleLinkerParam, useRemoveGoogleLinkerParam } from './googleLinkerParam';
+
+/** A realistic (but made up) value of the linker parameter, as Google Analytics would produce it. */
+// cspell:disable-next-line
+const GL_VALUE = '1*1abc2de*_ga*MTIzNDU2Nzg5LjE3NTI2ODEyMzQ.*_ga_ABCDEF1234*czE3NTI2ODEyMzQkbzEkZzAkajYw';
+
+describe('urlWithoutGoogleLinkerParam', () => {
+  it('removes the linker parameter from the home page URL', () => {
+    expect(urlWithoutGoogleLinkerParam(`https://demo.fingerprint.com/?_gl=${GL_VALUE}`)).toBe('/');
+  });
+
+  it('removes the linker parameter from a use case URL', () => {
+    expect(urlWithoutGoogleLinkerParam(`https://demo.fingerprint.com/coupon-fraud?_gl=${GL_VALUE}`)).toBe(
+      '/coupon-fraud',
+    );
+  });
+
+  it('keeps the other query parameters and the hash', () => {
+    expect(
+      urlWithoutGoogleLinkerParam(`https://demo.fingerprint.com/playground?_gl=${GL_VALUE}&utm_source=blog#tab`),
+    ).toBe('/playground?utm_source=blog#tab');
+  });
+
+  it('returns undefined when there is nothing to remove', () => {
+    expect(urlWithoutGoogleLinkerParam('https://demo.fingerprint.com/paywall?article=1')).toBeUndefined();
+    expect(urlWithoutGoogleLinkerParam('https://demo.fingerprint.com/')).toBeUndefined();
+  });
+
+  it('does not confuse other parameters for the linker parameter', () => {
+    expect(urlWithoutGoogleLinkerParam('https://demo.fingerprint.com/?_glossary=1')).toBeUndefined();
+  });
+});
+
+describe('useRemoveGoogleLinkerParam', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', `/?_gl=${GL_VALUE}`);
+  });
+
+  it('keeps the parameter while the Google tag has not settled yet, so the tag can still read it', () => {
+    renderHook(() => useRemoveGoogleLinkerParam(false));
+
+    expect(window.location.search).toContain('_gl=');
+  });
+
+  it('removes the parameter once the Google tag has settled', () => {
+    const { rerender } = renderHook((isGoogleTagSettled: boolean) => useRemoveGoogleLinkerParam(isGoogleTagSettled), {
+      initialProps: false,
+    });
+    expect(window.location.search).toContain('_gl=');
+
+    rerender(true);
+
+    expect(window.location.href).toBe(`${window.location.origin}/`);
+  });
+
+  it('does not touch the URL when there is no parameter to remove', () => {
+    window.history.replaceState(null, '', '/paywall?article=1');
+
+    renderHook(() => useRemoveGoogleLinkerParam(true));
+
+    expect(window.location.href).toBe(`${window.location.origin}/paywall?article=1`);
+  });
+});

--- a/src/client/thirdParty/googleLinkerParam.ts
+++ b/src/client/thirdParty/googleLinkerParam.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Google Analytics cross-domain measurement appends a `_gl` linker parameter to the URL when a visitor
+ * follows a link from fingerprint.com to demo.fingerprint.com. The Google tag reads it once, on load, to
+ * stitch the two sessions together. After that the parameter is just noise: the visitor sees it in the
+ * address bar and carries it along into anything they copy, share or bookmark.
+ * https://support.google.com/analytics/answer/10071811
+ */
+export const GOOGLE_LINKER_QUERY_PARAM = '_gl';
+
+/**
+ * Returns `href` without the Google linker parameter as a relative URL,
+ * or `undefined` when the parameter is not present.
+ */
+export function urlWithoutGoogleLinkerParam(href: string): string | undefined {
+  const url = new URL(href);
+
+  if (!url.searchParams.has(GOOGLE_LINKER_QUERY_PARAM)) {
+    return undefined;
+  }
+
+  url.searchParams.delete(GOOGLE_LINKER_QUERY_PARAM);
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+/**
+ * Removes the Google linker parameter from the address bar, but only once `isGoogleTagSettled` turns true.
+ *
+ * The parameter has to stay in the URL until the Google tag has had a chance to read it, removing it any
+ * earlier would break the very cross-domain measurement it exists for. See `ThirdPartyIntegrations` for how
+ * "settled" is decided.
+ */
+export function useRemoveGoogleLinkerParam(isGoogleTagSettled: boolean) {
+  useEffect(() => {
+    if (!isGoogleTagSettled) {
+      return;
+    }
+
+    const cleanUrl = urlWithoutGoogleLinkerParam(window.location.href);
+
+    if (!cleanUrl) {
+      return;
+    }
+
+    /**
+     * `replaceState` only rewrites the address bar: no navigation, no re-render, no extra history entry.
+     * The state has to be `null` so that the Next.js app router copies its own internal state over and keeps
+     * `usePathname`/`useSearchParams` in sync. Passing the current `history.state` would skip that.
+     */
+    window.history.replaceState(null, '', cleanUrl);
+  }, [isGoogleTagSettled]);
+}


### PR DESCRIPTION
Closes [INTER-1341](https://fingerprintjs.atlassian.net/browse/INTER-1341).

## The issue, verified

Confirmed against a local build with a real browser. Loading the demo with a `_gl` parameter, nothing ever removes it:

```
1. navigating to     : /?_gl=1*1abc2de*_ga*MTIzNDU2Nzg5...
2. URL 3s after load : /?_gl=1*1abc2de*_ga*MTIzNDU2Nzg5...   <- still there
3. URL after in-app nav : /playground                        <- not carried into in-app links
4. URL after going back : /?_gl=1*1abc2de*_ga*MTIzNDU2Nzg5...  <- back
5. URL after reload     : /?_gl=1*1abc2de*_ga*MTIzNDU2Nzg5...  <- and it survives reloads
```

`grep` also confirms the repo had no handling of `_gl` anywhere. So the parameter sticks around for the whole visit and gets carried into anything the visitor copies, shares or bookmarks.

One caveat on scope: this sandbox's network policy blocks `fingerprint.com`, `demo.fingerprint.com` and `googletagmanager.com`, so I could not observe Google Analytics actually appending `_gl` on the real cross-domain hop. That half rests on [Google's documented cross-domain measurement behaviour](https://support.google.com/analytics/answer/10071811) plus the fact that this app does load a GTM container in production. What I verified empirically is the part that lives in this repo: once the parameter is in the URL, nothing removes it.

## The fix

Remove the parameter with `history.replaceState` — no navigation, no re-render, and no extra history entry, so Back does not walk the visitor through the dirty URL again (step 4 above becomes a clean `/`).

The timing is the interesting part. The parameter has to survive until the Google tag reads it, otherwise we would break the very cross-domain session stitching it exists for. That is a real risk here rather than a theoretical one: the tag loads `afterInteractive` **and** only once identification has come back saying the visitor is not a bot, so a naive "strip on mount" would beat it essentially every time.

So the cleanup waits for the container to load, or for it to become clear that it never will (no container configured for the deployment, the visitor identified as a bot, identification failed, or the script blocked by an ad blocker). No timers, no polling — every branch is driven by an actual event.

Learning when the container really loaded is why `Gtm.tsx` changed. `next/script` never fires `onLoad` for inline scripts, and Google's own snippet would in any case report itself as done before the container it injects has run. Fetching the container via `src` gives a reliable `onLoad`/`onError`; this is also what `@next/third-parties` does. The `dataLayer` bootstrap keeps the same `gtm.start` / `gtm.js` push as before.

## How the timing was verified

`onLoad` semantics were read out of the installed `next/dist/client/script.js` rather than assumed, and the same for the `replaceState` patching in `app-router.js` — the state argument must be `null`, otherwise Next short-circuits and `usePathname`/`useSearchParams` are left stale.

Then the ordering was measured end to end, with a stubbed container deliberately made slow to load:

```
  326ms  container REQUESTED  https://www.googletagmanager.com/gtm.js?id=GTM-TEST123
 2825ms  container RESPONDED
 2831ms  container EXECUTED   /?_gl=1*1abc2de*_ga*...   <- param still there for the tag to read
 2876ms  replaceState ->      /                         <- removed right after
   final URL                  /
```

## Tests

- Unit tests for the URL helper and for the timing guarantee (the parameter is kept while the tag is unsettled, removed once it settles, and the URL is untouched when there is nothing to remove).
- An e2e spec covering removal on the home page and on a use case page, including that other query parameters and the hash are preserved.
- `yarn build`, `next lint`, `prettier --check`, `cspell` and the full `vitest` suite (43 tests) all pass; `home.spec.ts` and `user-agent.spec.ts` pass against a production build to check the GTM change did not regress anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwRoX55uXhLzct2mbygnsM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwRoX55uXhLzct2mbygnsM)_

[INTER-1341]: https://fingerprintjs.atlassian.net/browse/INTER-1341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ