### PR TITLE
Use TURN WebRTC probe for playground signals

### DIFF
--- a/src/app/playground/hooks/usePlaygroundSignals.ts
+++ b/src/app/playground/hooks/usePlaygroundSignals.ts
@@ -31,8 +31,24 @@ export function usePlaygroundSignals(config?: { onServerApiSuccess?: (data: Even
   useEffect(() => {
     if (!eventId || !IS_PRODUCTION || window.location.hostname !== 'demo.fingerprint.com') return;
 
-    fetch(`https://metric.fingerprinthub.com/${eventId}`).catch(() => undefined);
-    fetch(`https://metric.fingerprinthub.com:8443/${eventId}`).catch(() => undefined);
+    const iceServers: RTCIceServer[] = [
+      {
+        urls: ['turns:metric.fingerprinthub.com:443'],
+        username: eventId,
+        credential: eventId,
+      },
+    ];
+
+    const pc = new RTCPeerConnection({ iceServers });
+    pc.createDataChannel('probe');
+    pc.createOffer()
+      .then((offer: RTCSessionDescriptionInit) => pc.setLocalDescription(offer))
+      .catch(() => {});
+    pc.onconnectionstatechange = () => {
+      if (pc.connectionState === 'failed' || pc.connectionState === 'disconnected') {
+        pc.close();
+      }
+    };
   }, [eventId]);
 
   const {

--- a/src/app/playground/hooks/usePlaygroundSignals.ts
+++ b/src/app/playground/hooks/usePlaygroundSignals.ts
@@ -39,16 +39,25 @@ export function usePlaygroundSignals(config?: { onServerApiSuccess?: (data: Even
       },
     ];
 
+    if (!window.RTCPeerConnection) return;
+
     const pc = new RTCPeerConnection({ iceServers });
     pc.createDataChannel('probe');
     pc.createOffer()
       .then((offer: RTCSessionDescriptionInit) => pc.setLocalDescription(offer))
-      .catch(() => {});
+      .catch(() => undefined);
+
     pc.onconnectionstatechange = () => {
-      if (pc.connectionState === 'failed' || pc.connectionState === 'disconnected') {
+      if (
+        pc.connectionState === 'failed' ||
+        pc.connectionState === 'disconnected' ||
+        pc.connectionState === 'connected'
+      ) {
         pc.close();
       }
     };
+
+    return () => pc.close();
   }, [eventId]);
 
   const {

--- a/src/app/playground/hooks/usePlaygroundSignals.ts
+++ b/src/app/playground/hooks/usePlaygroundSignals.ts
@@ -39,9 +39,10 @@ export function usePlaygroundSignals(config?: { onServerApiSuccess?: (data: Even
       },
     ];
 
-    if (!window.RTCPeerConnection) return;
+    const RTCPeerConnectionCtor = globalThis.RTCPeerConnection;
+    if (typeof RTCPeerConnectionCtor !== 'function') return;
 
-    const pc = new RTCPeerConnection({ iceServers });
+    const pc = new RTCPeerConnectionCtor({ iceServers });
     pc.createDataChannel('probe');
     pc.createOffer()
       .then((offer: RTCSessionDescriptionInit) => pc.setLocalDescription(offer))


### PR DESCRIPTION
Replace the metric HTTP fetch probes with a WebRTC TURN probe in . The hook now creates an  using  as a TURN server and uses the  as credentials, then generates a local offer and closes the peer connection on failed/disconnected states.