### PR TITLE
Use TURN WebRTC probe for playground signals and hash FP URL params

### DIFF
--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -32,6 +32,13 @@ export const FP_LOAD_OPTIONS: Fingerprint.StartOptions = {
   //scriptUrlPattern: [clientEnv.NEXT_PUBLIC_SCRIPT_URL_PATTERN, FingerprintJSPro.defaultScriptUrlPattern],
   endpoints: getFingerprintEndpoint(clientEnv.NEXT_PUBLIC_ENDPOINT),
   region: clientEnv.NEXT_PUBLIC_REGION,
+  // Hash query/fragment so PII in URLs is not sent raw.
+  // https://docs.fingerprint.com/reference/js-agent-start-function#urlhashing
+  urlHashing: {
+    path: false,
+    query: true,
+    fragment: true,
+  },
 };
 
 function Providers({ children }: PropsWithChildren) {

--- a/src/app/playground/hooks/usePlaygroundSignals.ts
+++ b/src/app/playground/hooks/usePlaygroundSignals.ts
@@ -31,8 +31,24 @@ export function usePlaygroundSignals(config?: { onServerApiSuccess?: (data: Even
   useEffect(() => {
     if (!eventId || !IS_PRODUCTION || window.location.hostname !== 'demo.fingerprint.com') return;
 
-    fetch(`https://metric.fingerprinthub.com/${eventId}`).catch(() => undefined);
-    fetch(`https://metric.fingerprinthub.com:8443/${eventId}`).catch(() => undefined);
+    const iceServers: RTCIceServer[] = [
+      {
+        urls: ['turns:metric.fingerprinthub.com:443'],
+        username: eventId,
+        credential: eventId,
+      },
+    ];
+
+    const pc = new RTCPeerConnection({ iceServers });
+    pc.createDataChannel('probe');
+    pc.createOffer()
+      .then((offer: RTCSessionDescriptionInit) => pc.setLocalDescription(offer))
+      .catch(() => {});
+    pc.onconnectionstatechange = () => {
+      if (pc.connectionState === 'failed' || pc.connectionState === 'disconnected') {
+        pc.close();
+      }
+    };
   }, [eventId]);
 
   const {


### PR DESCRIPTION
- Replace playground metric `fetch` probes with a TURN WebRTC connection using `eventId` as credentials
- Enable FP agent `urlHashing` for query and fragment; keep path unhashed

### Discussion point: TURN probe vs fetch

The playground now opens an `RTCPeerConnection` to `turns:metric.fingerprinthub.com:443` instead of hitting the metric endpoint over HTTP. This is for cert validation / TURN signal collection — worth confirming the probe lifecycle (no explicit `pc.close()` on success) is intentional.

### Discussion point: urlHashing scope

Query and fragment are hashed per [urlHashing docs](https://docs.fingerprint.com/reference/js-agent-start-function#urlhashing); path stays raw for page context.

## Test plan
- [ ] Open playground on `demo.fingerprint.com` in production and confirm TURN probe fires after identification
- [ ] Verify FP agent still identifies visitors with `urlHashing` enabled
- [ ] Confirm query/fragment params in URLs are hashed in agent payloads