### PR TITLE
Hash FP agent URL query and fragment params

### DIFF
--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -32,6 +32,13 @@ export const FP_LOAD_OPTIONS: Fingerprint.StartOptions = {
   //scriptUrlPattern: [clientEnv.NEXT_PUBLIC_SCRIPT_URL_PATTERN, FingerprintJSPro.defaultScriptUrlPattern],
   endpoints: getFingerprintEndpoint(clientEnv.NEXT_PUBLIC_ENDPOINT),
   region: clientEnv.NEXT_PUBLIC_REGION,
+  // Hash query/fragment so PII in URLs is not sent raw.
+  // https://docs.fingerprint.com/reference/js-agent-start-function#urlhashing
+  urlHashing: {
+    path: false,
+    query: true,
+    fragment: true,
+  },
 };
 
 function Providers({ children }: PropsWithChildren) {


### PR DESCRIPTION
- Enable FP agent `urlHashing` for query and fragment; keep path unhashed

### Discussion point: urlHashing scope

Query and fragment are hashed per [urlHashing docs](https://docs.fingerprint.com/reference/js-agent-start-function#urlhashing); path stays raw for page context.

## Test plan
- [ ] Confirm query/fragment params in URLs are hashed in agent payloads